### PR TITLE
Add address property to message values

### DIFF
--- a/docs/xml/Buildetech.OscCore.xml
+++ b/docs/xml/Buildetech.OscCore.xml
@@ -82,6 +82,9 @@
         <member name="P:Buildetech.OscCore.OscMessageValues.ElementCount">
             <summary>The number of elements in the OSC Message</summary>
         </member>
+        <member name="P:Buildetech.OscCore.OscMessageValues.Address">
+            <summary>The OSC message address.</summary>
+        </member>
         <member name="M:Buildetech.OscCore.OscMessageValues.ForEachElement(System.Action{System.Int32,Buildetech.OscCore.TypeTag})">
             <summary>Execute a method for every element in the message</summary>
             <param name="elementAction">A method that takes in the index and type tag for an element</param>
@@ -347,6 +350,12 @@
         </member>
         <member name="M:Buildetech.OscCore.OscParser.ParseTags(System.Byte[],System.Int32)">
             <returns> Size of tags in bytes, including ',' </returns>
+        </member>
+        <member name="M:Buildetech.OscCore.OscParser.FindAddress(System.Int32)">
+            <summary>
+            Find the address string in the OSC packet and store it in the MessageValues property.
+            </summary>
+            <param name="offset">The starting offsetfor parsing the address, defaults to 0</param>
         </member>
         <member name="M:Buildetech.OscCore.OscParser.FindOffsets(System.Int32)">
             <summary>Find the byte offsets for each element of the message</summary>

--- a/src/Buildetech.OscCore.Test/Runtime/ParsingTests.cs
+++ b/src/Buildetech.OscCore.Test/Runtime/ParsingTests.cs
@@ -23,6 +23,7 @@ public class ParsingTests
     public void BeforeEach()
     {
         _parser.MessageValues.ElementCount = 0;
+        _parser.MessageValues.Address = string.Empty;
         Array.Clear(_parser._buffer, 0, BufferSize); // clear the buffer before each test
     }
 
@@ -112,5 +113,32 @@ public class ParsingTests
         Assert.AreEqual( new byte [] { 9, 8, 7 }, _parser.MessageValues.ReadBlobElement(1));
         Assert.AreEqual("xyz", _parser.MessageValues.ReadStringElement(2));
 
+    }
+
+    [Test]
+    public void AddressParsing()
+    {
+        
+        byte[] payloadBytes = new byte[]
+        {
+            (byte)'/', (byte)'m', (byte)'u', (byte)'l', (byte)'t', (byte)'i', (byte)'/', (byte)'c', 
+            (byte)'h', (byte)'a', (byte)'r', (byte)'_', (byte)'b', (byte)'y', (byte)'t', (byte)'e', 
+            (byte)'s', (byte)'_', (byte)'s', (byte)'t', (byte)'r', (byte)'i', (byte)'n', (byte)'g', 
+            (byte)0, (byte)0, (byte)0, (byte)0, (byte)',', (byte)'c', (byte)'b', (byte)'s', 
+            (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)0, (byte)'Z', 
+            (byte)0, (byte)0, (byte)0, (byte)3, (byte)9, (byte)8, (byte)7, (byte)0,
+            (byte)'x', (byte)'y', (byte)'z', (byte)0
+        };
+        
+        // manually copy into the parser buffer
+        for (var i = 0; i < payloadBytes.Length; i++)
+        {
+            _parser._buffer[i] = payloadBytes[i];
+        }
+
+        _ = _parser.Parse();
+        
+        Assert.AreEqual("/multi/char_bytes_string", _parser.MessageValues.Address);
+        
     }
 }

--- a/src/Buildetech.OscCore/Message/OscMessageValues.cs
+++ b/src/Buildetech.OscCore/Message/OscMessageValues.cs
@@ -50,10 +50,14 @@ public sealed unsafe partial class OscMessageValues
 
     /// <summary>The number of elements in the OSC Message</summary>
     public int ElementCount { get; internal set; }
+    
+    /// <summary>The OSC message address.</summary>
+    public string Address { get; internal set; }
 
     internal OscMessageValues(byte[] buffer, int elementCapacity = 8)
     {
         ElementCount = 0;
+        Address = string.Empty;
         _tags = new TypeTag[elementCapacity];
         _offsets = new int[elementCapacity];
         _sharedBuffer = buffer;

--- a/src/Buildetech.OscCore/OscParser.cs
+++ b/src/Buildetech.OscCore/OscParser.cs
@@ -59,6 +59,7 @@ public unsafe class OscParser
         var tagSize = ParseTags(_buffer, alignedAddressLength);
         var offset = alignedAddressLength + (tagSize + 4) & ~3;
         FindOffsets(offset);
+        FindAddress();
         return addressLength;
     }
 
@@ -84,6 +85,7 @@ public unsafe class OscParser
         var tagSize = ParseTags(_buffer, startPlusAlignedLength);
         var offset = startPlusAlignedLength + (tagSize + 4) & ~3;
         FindOffsets(offset);
+        FindAddress(offset);
         return addressLength;
     }
 
@@ -223,6 +225,20 @@ public unsafe class OscParser
 
         var length = index - offset + 1;  // need to account for the null terminator when aligning to 32 bits
         return (length + 3) & ~3;            // align to 4 bytes
+    }
+
+    /// <summary>
+    /// Find the address string in the OSC packet and store it in the MessageValues property.
+    /// </summary>
+    /// <param name="offset">The starting offsetfor parsing the address, defaults to 0</param>
+    public void FindAddress(int offset = 0)
+    {
+        
+        int addressLength =  FindUnalignedAddressLength(offset);
+        byte[] addressBytes = new byte[addressLength];
+        Buffer.BlockCopy(_buffer, offset, addressBytes, 0, addressLength);
+        MessageValues.Address = System.Text.Encoding.ASCII.GetString(addressBytes);
+
     }
 
     /// <summary>Find the byte offsets for each element of the message</summary>


### PR DESCRIPTION
Add the address property to the message value object so that the address for a received packet can be parsed and processed downstream.